### PR TITLE
ISSUE #34: Fix excessive number of query size() calls

### DIFF
--- a/vaadin-lazyquerycontainer/pom.xml
+++ b/vaadin-lazyquerycontainer/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.addons.lazyquerycontainer</groupId>
 	<artifactId>vaadin-lazyquerycontainer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.0</version>
+	<version>1.3.0.1</version>
 	<name>vaadin-lazyquerycontainer</name>
 
 	<properties>


### PR DESCRIPTION
I added an instance variable for the size of the query that gets cleared naturally by the container.
