### PR TITLE
NestedProperty support Refactored using NestingItem

### DIFF
--- a/vaadin-lazyquerycontainer-jpa-example/src/main/java/org/vaadin/addons/lazyquerycontainer/example/jpa/VaadinApplication.java
+++ b/vaadin-lazyquerycontainer-jpa-example/src/main/java/org/vaadin/addons/lazyquerycontainer/example/jpa/VaadinApplication.java
@@ -152,14 +152,13 @@ public class VaadinApplication extends UI implements ClickListener {
         entityContainer = new LazyEntityContainer<Task>(entityManager, Task.class, 100, "taskId", true, true, true);
         entityContainer.getQueryView().getQueryDefinition().setDefaultSortState(
                 new Object[]{"name"}, new boolean[]{true});
-        entityContainer.getQueryView().getQueryDefinition().setMaxNestedPropertyDepth(3);
 
         entityContainer.addContainerProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS, QueryItemStatus.class,
                 QueryItemStatus.None, true, false);
         entityContainer.addContainerProperty("taskId", Long.class, 0L, true, true);
         entityContainer.addContainerProperty("name", String.class, "", true, true);
-        entityContainer.addContainerProperty("author.name", String.class, "", true, true);
-        entityContainer.addContainerProperty("author.company.name", String.class, "", true, true);
+        entityContainer.addNestedProperty("author.name");
+        entityContainer.addNestedProperty("author.company.name");        
         entityContainer.addContainerProperty("reporter", String.class, "", true, true);
         entityContainer.addContainerProperty("assignee", String.class, "", true, true);
         entityContainer.addContainerProperty("alpha", String.class, "", false, true);

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/AbstractBeanQuery.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/AbstractBeanQuery.java
@@ -214,8 +214,7 @@ public abstract class AbstractBeanQuery<T> implements Query {
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
     private Item toItem(final T bean) {
-        NestingBeanItem<T> beanItem = new NestingBeanItem<T>(bean,
-                queryDefinition.getMaxNestedPropertyDepth(), queryDefinition.getPropertyIds());
+        NestingBeanItem<T> beanItem = new NestingBeanItem<T>(bean, queryDefinition.getPropertyIds());
 
         if (queryDefinition.isCompositeItems()) {
             CompositeItem compositeItem = new CompositeItem();

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/AbstractEntityContainer.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/AbstractEntityContainer.java
@@ -1,0 +1,123 @@
+package org.vaadin.addons.lazyquerycontainer;
+
+import java.util.Collection;
+
+import com.vaadin.data.util.BeanItem;
+
+/**
+ * An abstract class to provide default behaviors to EntityContainer's
+ * @author Eduardo Frazao - edufrazao@gmail.com
+ *
+ * @param <T> Entity Type
+ */
+public abstract class AbstractEntityContainer<T> extends LazyQueryContainer {
+
+	private static final long serialVersionUID = 1L;
+
+	public AbstractEntityContainer(QueryDefinition queryDefinition, QueryFactory queryFactory) {
+		super(queryDefinition, queryFactory);
+	}
+
+	public AbstractEntityContainer(QueryFactory queryFactory, Object idPropertyId, int batchSize, boolean compositeItems) {
+		super(queryFactory, idPropertyId, batchSize, compositeItems);
+	}
+
+	public AbstractEntityContainer(QueryView queryView) {
+		super(queryView);
+	}
+	
+	/**
+     * Adds entity to the container as first item i.e. at index 0.
+     *
+     * @return the new constructed entity.
+     */
+    public T addEntity() {
+        final Object itemId = addItem();
+        return getEntity(indexOfId(itemId));
+    }
+
+    /**
+     * Removes given entity at given index and returns it.
+     *
+     * @param index Index of the entity to be removed.
+     * @return The removed entity.
+     */
+    public T removeEntity(final int index) {
+        final T entityToRemove = getEntity(index);
+        removeItem(getIdByIndex(index));
+        return entityToRemove;
+    }
+
+    /**
+     * Gets entity by ID.
+     *
+     * @param id The ID of the entity.
+     * @return the entity.
+     */
+    public T getEntity(final Object id) {
+        return getEntity(indexOfId(id));
+    }
+
+    /**
+     * Gets entity at given index.
+     *
+     * @param index The index of the entity.
+     * @return the entity.
+     */
+    @SuppressWarnings("unchecked")
+    public T getEntity(final int index) {
+        if (getQueryView().getQueryDefinition().isCompositeItems()) {
+            final CompositeItem compositeItem = (CompositeItem) getItem(getIdByIndex(index));
+            final BeanItem<T> beanItem = (BeanItem<T>) compositeItem.getItem("bean");
+            return beanItem.getBean();
+        } else {
+            return ((BeanItem<T>) getItem(getIdByIndex(index))).getBean();
+        }
+    }
+
+	/**
+     * Returns an unmodifiable collection of user defined nested properties
+     * @return
+     */
+    public Collection<String> getNestedProperties() {
+    	return getQueryDefinitionFromQueryView().getNestedProperties();
+    }
+    
+    /**
+     * Add an nested property to this container<br>
+     * It uses the Java Beans API and conventions to access/invoke methods.<br>
+     * All access to properties will be done via default Getters and Setters, and not directly field acess. Be sure that your entity is<br>
+     * Java Beans conform.
+     * They will work only if you enable composite itens on this container
+     * @param nestedProperty - Nested properties on Java Beans notation (ie: entity.anotherEntity.propertyName)
+     */
+    public void addNestedProperty(final String nestedProperty) {
+    	if(nestedProperty != null && !nestedProperty.trim().isEmpty()) {
+    		Class<?> entityClass = getQueryDefinitionFromQueryView().getEntityClass();
+    		Class<?> propertyClass = EntityNestedProperty.getTypeFromPropertyPath(nestedProperty, entityClass);
+    		
+    		getQueryDefinitionFromQueryView().addNestedProperty(nestedProperty);
+        	super.addContainerProperty(nestedProperty, propertyClass, null);
+    	}
+    }
+    
+    /**
+     * Removes an nested property from this container
+     * @param nestedProperty
+     */
+    public void removeNestedProperty(final String nestedProperty) {
+    	if(getNestedProperties().contains(nestedProperty)) {
+    		getQueryDefinitionFromQueryView().removeNestedProperty(nestedProperty);
+        	super.removeContainerProperty(nestedProperty);
+    	}
+    }
+	
+    /**
+     * A convenience method that returns the EntityQueryDefinition with the correct type casted.
+     * @return
+     */
+    private EntityQueryDefinition getQueryDefinitionFromQueryView() {
+    	return (EntityQueryDefinition) getQueryView().getQueryDefinition();
+    }
+    
+}

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityContainer.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityContainer.java
@@ -15,8 +15,6 @@
  */
 package org.vaadin.addons.lazyquerycontainer;
 
-import com.vaadin.data.util.BeanItem;
-
 import javax.persistence.EntityManager;
 
 /**
@@ -26,7 +24,7 @@ import javax.persistence.EntityManager;
  * @param <T> Entity class.
  * @author Tommi Laukkanen
  */
-public final class EntityContainer<T> extends LazyQueryContainer {
+public final class EntityContainer<T> extends AbstractEntityContainer<T> {
     /**
      * Java serialization version UID.
      */
@@ -88,53 +86,5 @@ public final class EntityContainer<T> extends LazyQueryContainer {
                 nativeSortPropertyAscendingStates);
     }
 
-    /**
-     * Adds entity to the container as first item i.e. at index 0.
-     *
-     * @return the new constructed entity.
-     */
-    public T addEntity() {
-        final Object itemId = addItem();
-        return getEntity(indexOfId(itemId));
-    }
-
-    /**
-     * Removes given entity at given index and returns it.
-     *
-     * @param index Index of the entity to be removed.
-     * @return The removed entity.
-     */
-    public T removeEntity(final int index) {
-        final T entityToRemove = getEntity(index);
-        removeItem(getIdByIndex(index));
-        return entityToRemove;
-    }
-
-    /**
-     * Gets entity by ID.
-     *
-     * @param id The ID of the entity.
-     * @return the entity.
-     */
-    @SuppressWarnings("unchecked")
-    public T getEntity(final Object id) {
-        return getEntity(indexOfId(id));
-    }
-
-    /**
-     * Gets entity at given index.
-     *
-     * @param index The index of the entity.
-     * @return the entity.
-     */
-    @SuppressWarnings("unchecked")
-    public T getEntity(final int index) {
-        if (getQueryView().getQueryDefinition().isCompositeItems()) {
-            final CompositeItem compositeItem = (CompositeItem) getItem(getIdByIndex(index));
-            final BeanItem<T> beanItem = (BeanItem<T>) compositeItem.getItem("bean");
-            return beanItem.getBean();
-        } else {
-            return ((BeanItem<T>) getItem(getIdByIndex(index))).getBean();
-        }
-    }
+    
 }

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityNestedProperty.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityNestedProperty.java
@@ -1,0 +1,220 @@
+package org.vaadin.addons.lazyquerycontainer;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import com.vaadin.data.util.AbstractProperty;
+
+/**
+ * An implementation of <tt>Property<tt> that supports 1:1 nested properties<br>
+ * on Java Beans even with null references
+ * @author Eduardo Frazao - edufrazao@gmail.com
+ *
+ * @param <T> Type of Property
+ */
+public class EntityNestedProperty<T> extends AbstractProperty<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private Serializable entity;
+	
+	private String nestedProperty;
+	private PropertyDescriptor nestedPropertyDescriptor;
+	private Object nestedTarget;
+	private Class<T> nestedTargetClass;
+	
+	/**
+	 * Returns a new Item
+	 * @param entity
+	 * @param nestedProperty
+	 */
+	public EntityNestedProperty(final Serializable entity, final String nestedProperty) {
+		super();
+		if(entity == null || nestedProperty == null) {
+			throw new NullPointerException("Constructor fields cannot be null");
+		}
+		if(nestedProperty.trim().isEmpty()) {
+			throw new IllegalArgumentException("Nested property path cannot be empty");
+		}
+		this.entity = entity;
+		this.nestedProperty = nestedProperty.trim();
+		
+		nestedTargetClass = getTypeFromPropertyPath();
+	}
+
+	@Override
+	public T getValue() {
+		findPropertyDescriptor(); // Refreshs local references
+		if(nestedTarget != null) {
+			Method method = nestedPropertyDescriptor.getReadMethod();
+			try {
+				return getType().cast(method.invoke(nestedTarget, new Object[0]));
+			} catch (Exception e) {
+				throw new IllegalArgumentException(
+						String.format("Unable to invoke read method [%s] from the nested property [%s]", 
+								method.getName(), nestedTarget.getClass().getName()));
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void setValue(T newValue) throws com.vaadin.data.Property.ReadOnlyException {
+		if(isReadOnly()) {
+			throw new ReadOnlyException();
+		}
+		findPropertyDescriptor(); // Refreshs local references
+		if(nestedTarget != null) {
+			Method method = nestedPropertyDescriptor.getWriteMethod();
+			if(method == null) {
+				throw new IllegalStateException(
+						String.format("The property [%] does not have an write method", nestedPropertyDescriptor.getName()));
+			}
+			try {
+				if(newValue != null && !method.getParameterTypes()[0].isAssignableFrom(newValue.getClass())) {
+					throw new IllegalArgumentException(
+							String.format("Unable to set value of type [%s] on the property [%] with type [%]",
+							newValue.getClass().getName(),
+							nestedPropertyDescriptor.getName(),
+							method.getParameterTypes()[0].getName()
+							));
+				}
+				method.invoke(nestedTarget, new Object[] {newValue});
+			} catch (Exception e) {
+				throw new IllegalArgumentException(
+						String.format("Unable to invoke write method [%s] from the nested property [%s]", 
+								method.getName(), nestedTarget.getClass().getName()));
+			}
+		} else {
+			throw new NullPointerException("Unable to set value because the nested property is null");
+		}
+	}
+	
+	@Override
+	public Class<? extends T> getType() {
+		return nestedTargetClass;
+	}
+	
+	/**
+	 * 
+	 * Recursivelly iterates properties to reach the last target if possible (null is acceptable)
+	 * This method will keep a reference to the very last property descriptor, and the last target
+	 * object that owns the property. This will cache this recursive operation and permits that
+	 * the getValue() methods directly calls the getter of property without cache this result.
+	 * 
+	 */
+	private void findPropertyDescriptor() {
+		if(nestedProperty.contains(".")) {
+			String[] properties = nestedProperty.split("\\.");
+			Object target = entity;
+			PropertyDescriptor pd = null;
+			int counter = 1; // 1 based
+			for(String property : properties) {
+				try {
+					if(target != null) {
+						pd = getPropertyDescriptorFromProperty(property, target.getClass());
+						if(counter < properties.length) {
+							target = pd.getReadMethod().invoke(target, new Object[0]);
+						}
+					} else {
+						pd = null;
+						target = null;
+						break;
+					}
+				} catch (Exception e) {
+					throw new IllegalArgumentException(
+							String.format("Unable to invoke read method from property [%s] of target [%s] while iterating nested property path", property, target.getClass().getName()));
+				}
+				counter++;
+			}
+			nestedPropertyDescriptor = pd;
+			nestedTarget = target;
+		} else {
+			nestedPropertyDescriptor = getPropertyDescriptorFromProperty(nestedProperty, entity.getClass());
+		}
+	}
+	
+	
+	/**
+	 * Local helper that uses class context objects do call static methods
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	private Class<T> getTypeFromPropertyPath() {
+		return (Class<T>) getTypeFromPropertyPath(nestedProperty, entity.getClass());
+	}
+	
+	
+	// Local and Package Helper Methods
+	/**
+	 * Returns the type of the property using its read method as reference
+	 * @param propertyName
+	 * @param ownerClass
+	 * @return
+	 */
+	protected static Class<?> getTypeOfProperty(String propertyName, Class<?> ownerClass) {
+		PropertyDescriptor pd = getPropertyDescriptorFromProperty(propertyName, ownerClass);
+		Method method = pd.getReadMethod();
+		if(method != null) {
+			return method.getReturnType();
+		}
+		throw new IllegalArgumentException(String.format("Property [%s] not found on target [%s]", propertyName, ownerClass.getName()));
+	}
+	
+	/**
+	 * Returns the last property type of the nested property dotted expression
+	 * @param nestedProperty
+	 * @param entityClass
+	 * @return
+	 */
+	protected static Class<?> getTypeFromPropertyPath(final String nestedProperty, final Class<?> entityClass) {
+		if(nestedProperty.contains(".")) {
+			Class<?> clazz = entityClass;
+			String[] properties = nestedProperty.split("\\.");
+			for(String property : properties) {
+				clazz = getTypeOfProperty(property, clazz);
+				if(Collection.class.isAssignableFrom(clazz) || clazz.isArray()) {
+					throw new IllegalArgumentException(
+							String.format("This implementation does not support nested collections or arrays as properties: [%s] of [%s]",
+									property,
+									clazz.getName()
+									));
+				}
+			}
+			return clazz;
+		} else {
+			return getTypeOfProperty(nestedProperty, entityClass);
+		}
+	}
+
+	/**
+	 * Fetch the Java Beans property descriptor of an target
+	 * @param propertyName The name of property
+	 * @param target Target to Collect
+	 * @return Java Bean property descriptor
+	 * @throws IllegalArgumentException - In the case that no property descriptor is found for this property name
+	 */
+	protected static PropertyDescriptor getPropertyDescriptorFromProperty(String propertyName, Class<?> objectClass) throws IllegalArgumentException {
+		
+		try {
+			BeanInfo beanInfo = Introspector.getBeanInfo(objectClass);
+			
+			for(PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
+				if(pd.getName().equals(propertyName)) {
+					return pd;
+				}
+			}
+		} catch (IntrospectionException ex) {
+			throw new IllegalStateException(String.format("Unable to introspect class [%s]", objectClass.getName()));
+		}
+		
+		throw new IllegalArgumentException(String.format("No property descriptor found for the property [%s] of target class [%s]", propertyName, objectClass.getName()));
+		
+	}
+	
+}

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityQuery.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityQuery.java
@@ -41,6 +41,7 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -463,26 +464,27 @@ public class EntityQuery<E> implements Query, Serializable {
      */
     @SuppressWarnings({"rawtypes", "unchecked" })
     protected final Item toItem(final Object entity) {
+    	final NestingBeanItem<?> beanItem = new NestingBeanItem<Object>(entity, queryDefinition.getPropertyIds());
+    	
+    	for(String nestedProperty : queryDefinition.getNestedProperties()) {
+    		beanItem.addNestedProperty(nestedProperty);
+    	}
+    	
         if (queryDefinition.isCompositeItems()) {
-            final NestingBeanItem<?> beanItem = new NestingBeanItem<Object>(entity,
-                    queryDefinition.getMaxNestedPropertyDepth(), queryDefinition.getPropertyIds());
-
             final CompositeItem compositeItem = new CompositeItem();
             compositeItem.addItem("bean", beanItem);
-
+   
             for (final Object propertyId : queryDefinition.getPropertyIds()) {
                 if (compositeItem.getItemProperty(propertyId) == null) {
-                    compositeItem.addItemProperty(
+                	compositeItem.addItemProperty(
                             propertyId,
                             new ObjectProperty(queryDefinition.getPropertyDefaultValue(propertyId), queryDefinition
                                     .getPropertyType(propertyId), queryDefinition.isPropertyReadOnly(propertyId)));
                 }
             }
-
             return compositeItem;
         } else {
-            return new NestingBeanItem<Object>(entity,
-                    queryDefinition.getMaxNestedPropertyDepth(), queryDefinition.getPropertyIds());
+            return beanItem;
         }
     }
 

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityQueryDefinition.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/EntityQueryDefinition.java
@@ -15,6 +15,10 @@
  */
 package org.vaadin.addons.lazyquerycontainer;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
 /**
  * Defines entity query definition to be used with JPA entity managers.
  *
@@ -37,6 +41,11 @@ public class EntityQueryDefinition extends LazyQueryDefinition {
      * True if application manages transactions instead of container.
      */
     private boolean applicationManagedTransactions;
+    
+    /**
+     * Nested properties collection
+     */
+    private Collection<String> nestedProperties = new LinkedHashSet<String>();
 
 
     /**
@@ -80,6 +89,30 @@ public class EntityQueryDefinition extends LazyQueryDefinition {
      */
     public final Class<?> getEntityClass() {
         return entityClass;
+    }
+    
+    /**
+     * Returns an unmodifiable collection of user defined nested properties
+     * @return
+     */
+    public Collection<String> getNestedProperties() {
+    	return Collections.unmodifiableCollection(nestedProperties);
+    }
+    
+    /**
+     * Add an nested property to this query definition
+     * @param nestedProperty
+     */
+    public void addNestedProperty(final String nestedProperty) {
+    	nestedProperties.add(nestedProperty);
+    }
+    
+    /**
+     * Removes an nested property from this query definition
+     * @param nestedProperty
+     */
+    public void removeNestedProperty(final String nestedProperty) {
+    	nestedProperties.remove(nestedProperty);
     }
 
 }

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyEntityContainer.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyEntityContainer.java
@@ -15,8 +15,6 @@
  */
 package org.vaadin.addons.lazyquerycontainer;
 
-import com.vaadin.data.util.BeanItem;
-
 import javax.persistence.EntityManager;
 /**
  * LazyEntityContainer enables using JPA entities with lazy batch loading, filter, sort
@@ -25,7 +23,7 @@ import javax.persistence.EntityManager;
  * @param <T> Entity class.
  * @author Tommi Laukkanen
  */
-public final class LazyEntityContainer<T> extends LazyQueryContainer {
+public final class LazyEntityContainer<T> extends AbstractEntityContainer<T> {
     /**
      * Java serialization version UID.
      */
@@ -81,56 +79,6 @@ public final class LazyEntityContainer<T> extends LazyQueryContainer {
                 new EntityQueryFactory(entityManager));
         getQueryView().getQueryDefinition().setDefaultSortState(nativeSortPropertyIds,
                 nativeSortPropertyAscendingStates);
-    }
-
-    /**
-     * Adds entity to the container as first item i.e. at index 0.
-     *
-     * @return the new constructed entity.
-     */
-    public T addEntity() {
-        final Object itemId = addItem();
-        return getEntity(indexOfId(itemId));
-    }
-
-    /**
-     * Removes given entity at given index and returns it.
-     *
-     * @param index Index of the entity to be removed.
-     * @return The removed entity.
-     */
-    public T removeEntity(final int index) {
-        final T entityToRemove = getEntity(index);
-        removeItem(getIdByIndex(index));
-        return entityToRemove;
-    }
-
-    /**
-     * Gets entity by ID.
-     *
-     * @param id The ID of the entity.
-     * @return the entity.
-     */
-    @SuppressWarnings("unchecked")
-    public T getEntity(final Object id) {
-        return getEntity(indexOfId(id));
-    }
-
-    /**
-     * Gets entity at given index.
-     *
-     * @param index The index of the entity.
-     * @return the entity.
-     */
-    @SuppressWarnings("unchecked")
-    public T getEntity(final int index) {
-        if (getQueryView().getQueryDefinition().isCompositeItems()) {
-            final CompositeItem compositeItem = (CompositeItem) getItem(getIdByIndex(index));
-            final BeanItem<T> beanItem = (BeanItem<T>) compositeItem.getItem("bean");
-            return beanItem.getBean();
-        } else {
-            return ((BeanItem<T>) getItem(getIdByIndex(index))).getBean();
-        }
     }
 
 }

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryDefinition.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryDefinition.java
@@ -97,11 +97,7 @@ public class LazyQueryDefinition implements QueryDefinition, Serializable {
      * The query max size.
      */
     private int maxQuerySize = -1;
-    /**
-     * The max depth of nested properties.
-     */
-    private int maxNestedPropertyDepth = 0;
-
+    
     /**
      * Constructor which sets the batch size.
      *
@@ -442,23 +438,4 @@ public class LazyQueryDefinition implements QueryDefinition, Serializable {
         this.maxQuerySize = maxQuerySize;
     }
 
-    /**
-     * Sets the maxNestedPropertyDepth
-     *
-     * @return maxNestedPropertyDepth
-     */
-    @Override
-    public final int getMaxNestedPropertyDepth() {
-        return maxNestedPropertyDepth;
-    }
-
-    /**
-     * Gets the maxNestedPropertyDepth
-     *
-     * @param maxNestedPropertyDepth maxNestedPropertyDepth
-     */
-    @Override
-    public final void setMaxNestedPropertyDepth(final int maxNestedPropertyDepth) {
-        this.maxNestedPropertyDepth = maxNestedPropertyDepth;
-    }
 }

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/NestingBeanItem.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/NestingBeanItem.java
@@ -16,26 +16,10 @@
  */
 package org.vaadin.addons.lazyquerycontainer;
 
-import com.vaadin.data.Property;
 import com.vaadin.data.util.BeanItem;
-import com.vaadin.data.util.MethodPropertyDescriptor;
-import com.vaadin.data.util.NestedMethodProperty;
-import com.vaadin.data.util.PropertysetItem;
-import com.vaadin.data.util.VaadinPropertyDescriptor;
 
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.io.Serializable;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Specialized version of BeanItem to allow for automated expansion of nested properties.
@@ -48,153 +32,21 @@ import java.util.Set;
 @SuppressWarnings("serial")
 public class NestingBeanItem<BT> extends BeanItem<BT> {
 
-    /**
-     * The max nested property depth.
-     */
-    private final int maxNestedPropertyDepth;
+	public NestingBeanItem(BT bean, Collection<?> propertyIds) {
+		super(bean, propertyIds);
+	}
 
-    /**
-     * Constructor for defining the nested bean item parameters.
-     *
-     * @param bean the bean
-     * @param maxNestedPropertyDepth the max nested property depth.
-     * @param propertyIds the propertyIds
-     */
-    public NestingBeanItem(final BT bean, final int maxNestedPropertyDepth, final Collection<Object> propertyIds) {
-        super(bean);
+	public NestingBeanItem(BT bean, String[] propertyIds) {
+		super(bean, propertyIds);
+	}
 
-        this.maxNestedPropertyDepth = maxNestedPropertyDepth;
+	public NestingBeanItem(BT bean) {
+		super(bean);
+	}
 
-        if (maxNestedPropertyDepth > 0) {
-            for (final Object propertyId : propertyIds) {
-                final String propertyName = (String) propertyId;
-                if (propertyName.indexOf('.') > -1) {
-                    final String[] parts = propertyName.split("\\.");
-                    final StringBuilder nameBuilder = new StringBuilder();
-                    for (int i = 0; i < parts.length - 1; i++) {
-                        if (nameBuilder.length() == 0) {
-                            nameBuilder.append(parts[i]);
-                        } else {
-                            nameBuilder.append('.');
-                            nameBuilder.append(parts[i]);
-                        }
+	@Override
+	public void addNestedProperty(String nestedPropertyId) {
+		addItemProperty(nestedPropertyId, new EntityNestedProperty<BT>((Serializable) getBean(), nestedPropertyId));
+	}
 
-                        final String parentPropertyName = nameBuilder.toString();
-                        final String childPropertyName = parentPropertyName + "." + parts[i + 1];
-                        if (!getItemPropertyIds().contains(childPropertyName)) {
-                            expandProperty(parentPropertyName, parts[i + 1]);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Expands nested bean properties by replacing a top-level property with
-     * some or all of its sub-properties. The expansion is not recursive.
-     *
-     * @param propertyId
-     *            property id for the property whose sub-properties are to be
-     *            expanded,
-     * @param subPropertyIds
-     *            sub-properties to expand, all sub-properties are expanded if
-     *            not specified
-     */
-    public void expandProperty(String propertyId, String... subPropertyIds) {
-        Set<String> subPropertySet = new HashSet<String>(
-                Arrays.asList(subPropertyIds));
-
-        if (0 == subPropertyIds.length) {
-            // Enumerate all sub-properties
-            Class<?> propertyType = getItemProperty(propertyId).getType();
-            Map<String, ?> pds = getPropertyDescriptors(propertyType);
-            subPropertySet.addAll(pds.keySet());
-        }
-
-        for (String subproperty : subPropertySet) {
-            String qualifiedPropertyId = propertyId + "." + subproperty;
-            addNestedProperty(qualifiedPropertyId);
-        }
-
-    }
-
-    /**
-     * <p>
-     * Perform introspection on a Java Bean class to find its properties.
-     * </p>
-     *
-     * <p>
-     * Note : This version only supports introspectable bean properties and
-     * their getter and setter methods. Stand-alone <code>is</code> and
-     * <code>are</code> methods are not supported.
-     * </p>
-     *
-     * @param beanClass
-     *            the Java Bean class to get properties for.
-     * @return an ordered map from property names to property descriptors
-     */
-    static <BT> LinkedHashMap<String, VaadinPropertyDescriptor<BT>> getPropertyDescriptors(
-            final Class<BT> beanClass) {
-        final LinkedHashMap<String, VaadinPropertyDescriptor<BT>> pdMap = new LinkedHashMap<String, VaadinPropertyDescriptor<BT>>();
-
-        // Try to introspect, if it fails, we just have an empty Item
-        try {
-            List<PropertyDescriptor> propertyDescriptors = getBeanPropertyDescriptor(beanClass);
-
-            // Add all the bean properties as MethodProperties to this Item
-            // later entries on the list overwrite earlier ones
-            for (PropertyDescriptor pd : propertyDescriptors) {
-                final Method getMethod = pd.getReadMethod();
-                if ((getMethod != null)
-                        && getMethod.getDeclaringClass() != Object.class) {
-                    VaadinPropertyDescriptor<BT> vaadinPropertyDescriptor = new MethodPropertyDescriptor<BT>(
-                            pd.getName(), pd.getPropertyType(),
-                            pd.getReadMethod(), pd.getWriteMethod());
-                    pdMap.put(pd.getName(), vaadinPropertyDescriptor);
-                }
-            }
-        } catch (final java.beans.IntrospectionException ignored) {
-        }
-
-        return pdMap;
-    }
-
-    /**
-     * Returns the property descriptors of a class or an interface.
-     *
-     * For an interface, superinterfaces are also iterated as Introspector does
-     * not take them into account (Oracle Java bug 4275879), but in that case,
-     * both the setter and the getter for a property must be in the same
-     * interface and should not be overridden in subinterfaces for the discovery
-     * to work correctly.
-     *
-     * For interfaces, the iteration is depth first and the properties of
-     * superinterfaces are returned before those of their subinterfaces.
-     *
-     * @param beanClass
-     * @return
-     * @throws IntrospectionException
-     */
-    private static List<PropertyDescriptor> getBeanPropertyDescriptor(
-            final Class<?> beanClass) throws IntrospectionException {
-        // Oracle bug 4275879: Introspector does not consider superinterfaces of
-        // an interface
-        if (beanClass.isInterface()) {
-            List<PropertyDescriptor> propertyDescriptors = new ArrayList<PropertyDescriptor>();
-
-            for (Class<?> cls : beanClass.getInterfaces()) {
-                propertyDescriptors.addAll(getBeanPropertyDescriptor(cls));
-            }
-
-            BeanInfo info = Introspector.getBeanInfo(beanClass);
-            propertyDescriptors.addAll(Arrays.asList(info
-                    .getPropertyDescriptors()));
-
-            return propertyDescriptors;
-        } else {
-            BeanInfo info = Introspector.getBeanInfo(beanClass);
-            return Arrays.asList(info.getPropertyDescriptors());
-        }
-    }
 }

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/QueryDefinition.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/QueryDefinition.java
@@ -257,17 +257,4 @@ public interface QueryDefinition {
      */
     void setMaxQuerySize(final int maxQuerySize);
 
-    /**
-     * Sets the maxNestedPropertyDepth
-     *
-     * @return maxNestedPropertyDepth
-     */
-    int getMaxNestedPropertyDepth();
-
-    /**
-     * Gets the maxNestedPropertyDepth
-     *
-     * @param maxNestedPropertyDepth maxNestedPropertyDepth
-     */
-    void setMaxNestedPropertyDepth(int maxNestedPropertyDepth);
 }

--- a/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerAttachedEntitiesPropertyIdsTest.java
+++ b/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerAttachedEntitiesPropertyIdsTest.java
@@ -92,7 +92,6 @@ public class EntityContainerAttachedEntitiesPropertyIdsTest {
                 ENTITY_CONTAINER_BATCH_SIZE, "taskId", true, false, true);
         entityContainer.getQueryView().getQueryDefinition().setDefaultSortState(
                 new String[]{"name"}, new boolean[]{true});
-        entityContainer.getQueryView().getQueryDefinition().setMaxNestedPropertyDepth(3);
 
         final Company company = new Company();
         company.setName("test-company");
@@ -167,8 +166,8 @@ public class EntityContainerAttachedEntitiesPropertyIdsTest {
                 betaItemBeforeRefresh.getItemProperty("description"));
 
         entityContainer.addContainerProperty("description", String.class, "");
-        entityContainer.addContainerProperty("author.name", String.class, "");
-        entityContainer.addContainerProperty("author.company.name", String.class, "");
+        entityContainer.addNestedProperty("author.name");
+        entityContainer.addNestedProperty("author.company.name");
         entityContainer.refresh();
 
         final Item betaItem = entityContainer.getItem(taskBeta.getTaskId());

--- a/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerAttachedEntitiesTest.java
+++ b/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerAttachedEntitiesTest.java
@@ -16,7 +16,6 @@
 package org.vaadin.addons.lazyquerycontainer.test;
 
 import com.vaadin.data.Item;
-import com.vaadin.data.util.BeanItem;
 import com.vaadin.data.util.filter.And;
 import com.vaadin.data.util.filter.Compare;
 import junit.framework.Assert;
@@ -91,7 +90,6 @@ public class EntityContainerAttachedEntitiesTest {
                 ENTITY_CONTAINER_BATCH_SIZE, null, true, false, true);
         entityContainer.getQueryView().getQueryDefinition().setDefaultSortState(
                 new String[]{"name"}, new boolean[]{true});
-        entityContainer.getQueryView().getQueryDefinition().setMaxNestedPropertyDepth(3);
 
         final Company company = new Company();
         company.setName("test-company");
@@ -167,8 +165,8 @@ public class EntityContainerAttachedEntitiesTest {
                 betaItemBeforeRefresh.getItemProperty("description"));
 
         entityContainer.addContainerProperty("description", String.class, "");
-        entityContainer.addContainerProperty("author.name", String.class, "");
-        entityContainer.addContainerProperty("author.company.name", String.class, "");
+        entityContainer.addNestedProperty("author.name");
+        entityContainer.addNestedProperty("author.company.name");
 
         entityContainer.refresh();
 

--- a/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerDetachedEntitiesPropertyIdsTest.java
+++ b/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerDetachedEntitiesPropertyIdsTest.java
@@ -88,7 +88,6 @@ public class EntityContainerDetachedEntitiesPropertyIdsTest {
                 ENTITY_CONTAINER_BATCH_SIZE, "taskId", true, true, true);
         entityContainer.getQueryView().getQueryDefinition().setDefaultSortState(
                 new String[]{"name"}, new boolean[]{true});
-        entityContainer.getQueryView().getQueryDefinition().setMaxNestedPropertyDepth(3);
 
         final Company company = new Company();
         company.setName("test-company");
@@ -173,8 +172,8 @@ public class EntityContainerDetachedEntitiesPropertyIdsTest {
                 betaItemBeforeRefresh.getItemProperty("description"));
 
         entityContainer.addContainerProperty("description", String.class, "");
-        entityContainer.addContainerProperty("author.name", String.class, "");
-        entityContainer.addContainerProperty("author.company.name", String.class, "");
+        entityContainer.addNestedProperty("author.name");
+        entityContainer.addNestedProperty("author.company.name");
 
         entityContainer.refresh();
 

--- a/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerDetachedEntitiesTest.java
+++ b/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityContainerDetachedEntitiesTest.java
@@ -88,7 +88,6 @@ public class EntityContainerDetachedEntitiesTest {
                 ENTITY_CONTAINER_BATCH_SIZE, null, true, true, true);
         entityContainer.getQueryView().getQueryDefinition().setDefaultSortState(
                 new String[]{"name"}, new boolean[]{true});
-        entityContainer.getQueryView().getQueryDefinition().setMaxNestedPropertyDepth(3);
 
         final Company company = new Company();
         company.setName("test-company");
@@ -173,8 +172,8 @@ public class EntityContainerDetachedEntitiesTest {
                 betaItemBeforeRefresh.getItemProperty("description"));
 
         entityContainer.addContainerProperty("description", String.class, "");
-        entityContainer.addContainerProperty("author.name", String.class, "");
-        entityContainer.addContainerProperty("author.company.name", String.class, "");
+        entityContainer.addNestedProperty("author.name");
+        entityContainer.addNestedProperty("author.company.name");
 
         entityContainer.refresh();
 

--- a/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityNestedPropertyTest.java
+++ b/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/EntityNestedPropertyTest.java
@@ -1,0 +1,200 @@
+package org.vaadin.addons.lazyquerycontainer.test;
+
+import java.io.Serializable;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.vaadin.addons.lazyquerycontainer.EntityNestedProperty;
+
+/**
+ * Unit tests for the EntityNestedProperty
+ * @author Eduardo Frazao - edufrazao@gmail.com
+ *
+ */
+public class EntityNestedPropertyTest {
+
+	SomeEntity entity = new SomeEntity(1, "A Name", null);
+	
+	@Test
+	public void testReadNullNestedProperties() {
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.id");
+		
+		Assert.assertNull("Property read on null nested property will only return null", propertyId.getValue());
+	}
+	
+	@Test
+	public void testReadNullNestesPropertiesManyLevels() {
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.anotherEntity.id");
+		Assert.assertNull("Property read on null nested property will only return null", propertyId.getValue());
+	}
+	
+	@Test
+	public void testReadNotNullNestedProperties() {
+		final Integer nestedPropertyId = 2;
+		final String nestedPropertyName = "Another Name";
+		
+		SomeEntity nestedProperty = new SomeEntity(new Integer(nestedPropertyId), new String(nestedPropertyName), null);
+		entity.setAnotherEntity(nestedProperty);
+		
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.id");
+		EntityNestedProperty<Object> propertyName = new EntityNestedProperty<Object>(entity, "anotherEntity.name");
+		
+		Assert.assertEquals(nestedPropertyId, propertyId.getValue());
+		Assert.assertEquals(nestedPropertyName, propertyName.getValue());
+	}
+	
+	@Test
+	public void testReadNotNullNestesPropertiesManyLevels() {
+		final Integer nestedPropertyId = 4;
+		final String nestedPropertyName = "Entity 4";
+		
+		SomeEntity nestedProperty4 = new SomeEntity(new Integer(nestedPropertyId), new String(nestedPropertyName), null);
+		SomeEntity nestedProperty3 = new SomeEntity(3, "Does not matter", nestedProperty4);
+		SomeEntity nestedProperty2 = new SomeEntity(2, "Does not matter", nestedProperty3);
+		
+		entity.setAnotherEntity(nestedProperty2);
+		
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.anotherEntity.id");
+		EntityNestedProperty<Object> propertyName = new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.anotherEntity.name");
+		
+		Assert.assertEquals(nestedPropertyId, propertyId.getValue());
+		Assert.assertEquals(nestedPropertyName, propertyName.getValue());
+	}
+	
+	@Test
+	public void testReadNotNullFromIntermediaryLevel() {
+		final Integer nestedPropertyId = 2;
+		final String nestedPropertyName = "Level 2";
+		
+		SomeEntity nestedProperty4 = new SomeEntity(4, "Does not matter", null);
+		SomeEntity nestedProperty3 = new SomeEntity(new Integer(nestedPropertyId), new String(nestedPropertyName), nestedProperty4);
+		SomeEntity nestedProperty2 = new SomeEntity(2, "Does not matter", nestedProperty3);
+		
+		entity.setAnotherEntity(nestedProperty2);
+		
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.id");
+		EntityNestedProperty<Object> propertyName = new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.name");
+		
+		Assert.assertEquals(nestedPropertyId, propertyId.getValue());
+		Assert.assertEquals(nestedPropertyName, propertyName.getValue());
+	}
+	
+	@Test
+	public void testReturnTypes() {
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.id");
+		EntityNestedProperty<Object> propertyName = new EntityNestedProperty<Object>(entity, "anotherEntity.name");
+		
+		Assert.assertEquals(Integer.class, propertyId.getType());
+		Assert.assertEquals(String.class, propertyName.getType());
+	}
+	
+	@Test
+	public void testReturnTypesFromManyLevels() {
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.anotherEntity.id");
+		EntityNestedProperty<Object> propertyName = new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.anotherEntity.name");
+		
+		Assert.assertEquals(Integer.class, propertyId.getType());
+		Assert.assertEquals(String.class, propertyName.getType());
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testAddingInexistentProperties() {
+		
+		new EntityNestedProperty<Object>(entity, "anotherEntity.anotherEntity.inexistentProperty.id");
+		
+	}
+	
+	// Write value
+	@Test(expected=NullPointerException.class)
+	public void testSetValueOnNullNestedProperty() {
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.id");
+		propertyId.setValue(1);
+	}
+	
+	@Test
+	public void testSetValueOnNotNullNestedProperty() {
+		SomeEntity nestedEntity = new SomeEntity(null, "Does not matter", null);
+		entity.setAnotherEntity(nestedEntity);
+		
+		EntityNestedProperty<Integer> propertyId = new EntityNestedProperty<Integer>(entity, "anotherEntity.id");
+		propertyId.setValue(125);
+		
+		Assert.assertEquals(new Integer(125), propertyId.getValue());
+	}
+	
+	@Test
+	public void testSetValueMultipleLevels() {
+		final Integer nestedPropertyId = 4;
+		final String nestedPropertyName = "Entity 4";
+		
+		SomeEntity nestedProperty4 = new SomeEntity(new Integer(nestedPropertyId), null, null);
+		SomeEntity nestedProperty3 = new SomeEntity(3, "Does not matter", nestedProperty4);
+		SomeEntity nestedProperty2 = new SomeEntity(2, "Does not matter", nestedProperty3);
+		
+		entity.setAnotherEntity(nestedProperty2);
+		
+		EntityNestedProperty<String> propertyName = new EntityNestedProperty<String>(entity, "anotherEntity.anotherEntity.anotherEntity.name");
+		propertyName.setValue(new String(nestedPropertyName));
+		
+		Assert.assertEquals(nestedPropertyName, propertyName.getValue());
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetValueWrongTyped() {
+		SomeEntity nestedEntity = new SomeEntity(null, "Does not matter", null);
+		entity.setAnotherEntity(nestedEntity);
+		
+		EntityNestedProperty<Object> propertyId = new EntityNestedProperty<Object>(entity, "anotherEntity.id");
+		propertyId.setValue("Setting a string on a Integer property");
+	}
+	
+	// An simple entity for tests
+	public static class SomeEntity implements Serializable {
+		
+		private static final long serialVersionUID = 1L;
+		
+		public SomeEntity() {
+			super();
+		}
+		
+		public SomeEntity(Integer id, String name, SomeEntity anotherEntity) {
+			this();
+			this.id = id;
+			this.name = name;
+			this.anotherEntity = anotherEntity;
+		}
+
+		// Normal properties
+		private Integer id;
+		private String name;
+		
+		// An nested property
+		private SomeEntity anotherEntity;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public SomeEntity getAnotherEntity() {
+			return anotherEntity;
+		}
+
+		public void setAnotherEntity(SomeEntity anotherEntity) {
+			this.anotherEntity = anotherEntity;
+		}
+	}
+
+}


### PR DESCRIPTION
Hi Tommi! I've made some changes on the initial pull request, and rebased it on top of your
Expect that it can be useful!

Refactor of initial propoused support of NestedProperties
- Nested properties with null relations implemented over
  NestingItem created by Tommi.
  - Small refactory to not expand properties automatically (addNestedProperty overrided)
  - Removed the Nested Property Depth configuration, as the user
    will configure nested properties directly over EntityContainers
  - Test cases refactored to use this changes.
