### PR TITLE
nextItemId/prevItemId should return null instead of throwing IndexOutOfBoundsException

### DIFF
--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryContainer.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryContainer.java
@@ -285,18 +285,32 @@ public class LazyQueryContainer implements Indexed, Sortable, ItemSetChangeNotif
 
     /**
      * @param itemId the item index
-     * @return itemId + 1
+     * @return itemId + 1, or <code>null</code> if no such item
      */
     public final Object nextItemId(final Object itemId) {
-        return queryView.getItemIdList().get(queryView.getItemIdList().indexOf(itemId) + 1);
+    	List<?> itemIdList = queryView.getItemIdList();
+    	int currentIndex = itemIdList.indexOf(itemId);
+    	if (currentIndex == -1 || currentIndex == itemIdList.size() - 1) {
+    		return null;
+    	}
+    	else {
+    		return itemIdList.get(currentIndex + 1);
+    	}
     }
 
     /**
      * @param itemId the item index
-     * @return itemId - 1
+     * @return itemId - 1, or <code>null</code> if no such item
      */
     public final Object prevItemId(final Object itemId) {
-        return queryView.getItemIdList().get(queryView.getItemIdList().indexOf(itemId) - 1);
+    	List<?> itemIdList = queryView.getItemIdList();
+    	int currentIndex = itemIdList.indexOf(itemId);
+    	if (currentIndex == -1 || currentIndex == 0) {
+    		return null;
+    	}
+    	else {
+    		return itemIdList.get(currentIndex - 1);
+    	}
     }
 
     /**

--- a/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/LazyQueryContainerTest.java
+++ b/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/LazyQueryContainerTest.java
@@ -240,4 +240,13 @@ public class LazyQueryContainerTest extends TestCase implements ItemSetChangeLis
         assertFalse(container.getItem(removeIndex).getItemProperty("Editable").isReadOnly());
     }
 
+    public void testPrevItemId() {
+    	Object first = container.getIdByIndex(0);
+    	assertNull(container.prevItemId(first));
+    }
+
+    public void testNextItemId() {
+    	Object last = container.getIdByIndex(container.size() - 1);
+    	assertNull(container.nextItemId(last));
+    }
 }


### PR DESCRIPTION
According to com.vaadin.data.Container.Ordered methods nextItemId and prevItemId should return null values when the given item is the last/first or not found. 

This pull request contains a modification to LazyQueryContainer to follow the definition. In addition two tests were added to verify the functionality.
