### PR TITLE
Update MockQueryFactory.java

### DIFF
--- a/vaadin-lazyquerycontainer-mock-example/src/main/java/org/vaadin/addons/lazyquerycontainer/example/mock/MockQueryFactory.java
+++ b/vaadin-lazyquerycontainer-mock-example/src/main/java/org/vaadin/addons/lazyquerycontainer/example/mock/MockQueryFactory.java
@@ -52,6 +52,7 @@ public class MockQueryFactory implements QueryFactory {
     }
 
     public Query constructQuery(QueryDefinition definition) {
+        this.definition = definition;
         // Creating items on demand when constructQuery is first time called.
         if (items == null) {
             items = new ArrayList<Item>();


### PR DESCRIPTION
To avoid the following npe:

SEVERE: Servlet.service() for servlet [Lazy Application] in context with path [/Lazy] threw exception [com.vaadin.server.ServiceException: java.lang.NullPointerException] with root cause
java.lang.NullPointerException
at com.example.lazy.MockQueryFactory.constructItem(MockQueryFactory.java:64)
at com.example.lazy.MockQueryFactory.constructQuery(MockQueryFactory.java:45)
at org.vaadin.addons.lazyquerycontainer.LazyQueryView.getQuery(LazyQueryView.java:406)
at org.vaadin.addons.lazyquerycontainer.LazyQueryView.getQuerySize(LazyQueryView.java:392)
at org.vaadin.addons.lazyquerycontainer.LazyQueryView.size(LazyQueryView.java:219)
at org.vaadin.addons.lazyquerycontainer.LazyQueryContainer.size(LazyQueryContainer.java:183)
at com.vaadin.ui.AbstractSelect.size(AbstractSelect.java:762)
at com.vaadin.ui.Table.refreshRenderedCells(Table.java:1628)
at com.vaadin.ui.Table.enableContentRefreshing(Table.java:3143)
at com.vaadin.ui.Table.setContainerDataSource(Table.java:2712)
at com.vaadin.ui.Table.setContainerDataSource(Table.java:2653)
at com.example.lazy.LazyUI.init(LazyUI.java:124)
at com.vaadin.ui.UI.doInit(UI.java:556)
at com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI(UIInitHandler.java:217)
at com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest(UIInitHandler.java:72)
at com.vaadin.server.SynchronizedRequestHandler.handleRequest(SynchronizedRequestHandler.java:37)
at com.vaadin.server.VaadinService.handleRequest(VaadinService.java:1314)
at com.vaadin.server.VaadinServlet.service(VaadinServlet.java:195)
at javax.servlet.http.HttpServlet.service(HttpServlet.java:728)
at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:305)
at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:222)
at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:123)
at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:472)
at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:171)
at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:99)
at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:953)
at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:118)
at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:408)
at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1008)
at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:589)
at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:312)
at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
at java.lang.Thread.run(Unknown Source)
