### PR TITLE
Make LazyIdList actually serializable

### DIFF
--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyIdList.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyIdList.java
@@ -17,6 +17,7 @@ package org.vaadin.addons.lazyquerycontainer;
 
 import com.vaadin.data.Item;
 
+import java.io.Serializable;
 import java.util.AbstractList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,7 +30,7 @@ import java.util.Map;
  *
  * @author Tommi Laukkanen
  */
-public final class LazyIdList<T> extends AbstractList<T> {
+public final class LazyIdList<T> extends AbstractList<T> implements Serializable {
     /**
      * Java serialization version UID.
      */


### PR DESCRIPTION
While LazyIdList specifies serialVersionUID, it does not actually implement Serializable interface. Thanks to this LazyQueryView (and thus LazyQueryContainer itself) fail to serialize if LazyIdList is used.
