### PR TITLE
OSGi Compatibility Stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 .classpath
 .project
 .settings
+vaadin-lazyquerycontainer-jpa-example/bin/
+vaadin-lazyquerycontainer/bin/

--- a/vaadin-lazyquerycontainer/pom.xml
+++ b/vaadin-lazyquerycontainer/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vaadin.version>7.0.5</vaadin.version>
+        <bundlor.manifest.output.dir>target/classes</bundlor.manifest.output.dir>
     </properties>
 
     <repositories>
@@ -29,6 +30,14 @@
             <url>http://www.eclipse.org/downloads/download.php?r=1&amp;nf=1&amp;file=/rt/eclipselink/maven.repo</url>
         </repository>
     </repositories>
+    
+    <pluginRepositories>
+		<pluginRepository>
+			<id>com.springsource.repository.bundles.release</id>
+			<name>SpringSource Enterprise Bundle Repository</name>
+			<url>http://repository.springsource.com/maven/bundles/release</url>
+		</pluginRepository>
+	</pluginRepositories>
 
     <build>
         <plugins>
@@ -64,15 +73,61 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
-                        <manifestEntries>
-                            <Implementation-Title>Lazy Query Container</Implementation-Title>
-                            <Implementation-Version>${project.version}</Implementation-Version>
-                            <Vaadin-Package-Version>1</Vaadin-Package-Version>
-                        </manifestEntries>
+                        <manifestFile>${bundlor.manifest.output.dir}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+				<groupId>com.springsource.bundlor</groupId>
+				<artifactId>com.springsource.bundlor.maven</artifactId>
+				<version>1.0.0.RELEASE</version>
+				<executions>
+					<execution>
+						<id>bundlor</id>
+						<goals>
+							<goal>bundlor</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
+        
+        <pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											com.springsource.bundlor
+										</groupId>
+										<artifactId>
+											com.springsource.bundlor.maven
+										</artifactId>
+										<versionRange>
+											[1.0.0.RELEASE,)
+										</versionRange>
+										<goals>
+											<goal>bundlor</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
     </build>
 
     <reporting>

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/NestingBeanItem.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/NestingBeanItem.java
@@ -17,7 +17,6 @@
 package org.vaadin.addons.lazyquerycontainer;
 
 import com.vaadin.data.util.BeanItem;
-import com.vaadin.data.util.LazyNestedMethodProperty;
 import com.vaadin.data.util.MethodPropertyDescriptor;
 import com.vaadin.data.util.VaadinPropertyDescriptor;
 
@@ -34,6 +33,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.vaadin.addons.lazyquerycontainer.util.LazyNestedMethodProperty;
 
 /**
  * Specialized version of BeanItem to allow for automated expansion of nested properties.

--- a/vaadin-lazyquerycontainer/template.mf
+++ b/vaadin-lazyquerycontainer/template.mf
@@ -1,0 +1,15 @@
+Implementation-Title: Lazy Query Container
+Implementation-Version: ${project.version}
+Vaadin-Package-Version: 1
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.vaadin.addons.lazyquerycontainer
+Bundle-Name: Lazy Query Container
+Bundle-Vendor: Vaadin Community
+Excluded-Imports: 
+ com.google.gwt*,
+ com.vaadin.client.*
+Excluded-Exports: 
+ src.test.java.org.vaadin.addons.lazyquerycontainer.test.*
+Import-Template:
+ com.vaadin.*;version="[7.0.0, 8.0.0)",
+ javax.persistence.*;version="[1.1.0,2.1.0)"


### PR DESCRIPTION
- Misc: Added default bin/ directory as ignored (for eclipse users)
- Added Maven config to generate a OSGi Compliant MANIFEST.MF automatically
- Added a Bundlor template with some rules about package imports version
- Refactory of the LazyNestedProperty util class, as it packages conflicts with
  vaadin predefined
  - In normal Flat ClassPath this causes no issues, but with OSGi it becomes
    a big problem beasuse the Import directives, that causes this class to
    not be acessible even existing in the own bundle. A workaround is extract
    this class and inject it as a fragment on com.vaadin.server bundle.
  - As this class uses this namespace mainly to use use some protected static
    util methods of Vaadin (i think), I've refactored it consume this methods
    using reflection.
