### PR TITLE
Improvements to make lazyquerycontainer suitable for combo boxes in combination with large result sets

### DIFF
--- a/vaadin-lazyquerycontainer/pom.xml
+++ b/vaadin-lazyquerycontainer/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.vaadin.addons.lazyquerycontainer</groupId>
     <artifactId>vaadin-lazyquerycontainer</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.0</version>
+    <version>2.1.0.ms</version>
     <name>vaadin-lazyquerycontainer</name>
 
     <properties>

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/DefaultItemIdListFactory.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/DefaultItemIdListFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2010 Tommi S.E. Laukkanen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.addons.lazyquerycontainer;
 
 import java.util.AbstractList;
@@ -8,7 +23,7 @@ import java.util.AbstractList;
  * 
  * Be careful with the LazyIdList on large containers in combination with Vaadins combobox.
  * 
- * @author Michael J. Simons
+ * @author Michael J. Simons, 2013-11-28
  */
 public class DefaultItemIdListFactory implements ItemIdListFactory {
 	@Override

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/DefaultItemIdListFactory.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/DefaultItemIdListFactory.java
@@ -1,0 +1,24 @@
+package org.vaadin.addons.lazyquerycontainer;
+
+import java.util.AbstractList;
+
+/**
+ * Produces a LazyIdList when an IdPropertyId is definied in the querydefinition,
+ * uses otherwise a list of natural numbers.
+ * 
+ * Be careful with the LazyIdList on large containers in combination with Vaadins combobox.
+ * 
+ * @author Michael J. Simons
+ */
+public class DefaultItemIdListFactory implements ItemIdListFactory {
+	@Override
+	public AbstractList<?> produce(final QueryDefinition queryDefinition, final LazyQueryView queryView) {
+		AbstractList<?> rv = null;
+		if (queryDefinition.getIdPropertyId() != null) {
+			rv = new LazyIdList<Object>(queryView, queryDefinition.getIdPropertyId());
+        } else {
+            rv = new NaturalNumberIdsList(queryView.size());
+        }
+		return rv;
+	}	
+}

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/ItemIdListFactory.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/ItemIdListFactory.java
@@ -1,0 +1,16 @@
+package org.vaadin.addons.lazyquerycontainer;
+
+import java.util.AbstractList;
+
+/**
+ * Produces new ItemIdLists for the {@link LazyQueryView}
+ * @author Michael J. Simons
+ */
+public interface ItemIdListFactory {
+	/**
+	 * @param queryDefinition
+	 * @param queryView The query view which uses the ItemIdLists
+	 * @return
+	 */
+	public AbstractList<?> produce(final QueryDefinition queryDefinition, final LazyQueryView queryView); 
+}

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/ItemIdListFactory.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/ItemIdListFactory.java
@@ -1,10 +1,26 @@
+/**
+ * Copyright 2010 Tommi S.E. Laukkanen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.addons.lazyquerycontainer;
 
 import java.util.AbstractList;
 
 /**
  * Produces new ItemIdLists for the {@link LazyQueryView}
- * @author Michael J. Simons
+ * 
+ * @author Michael J. Simons, 2013-11-28
  */
 public interface ItemIdListFactory {
 	/**

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryView.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryView.java
@@ -102,7 +102,11 @@ public final class LazyQueryView implements QueryView, ValueChangeListener {
      */
     private boolean[] ascendingStates;
     /**
-     * List of item IDs.
+     * Factory for generating new itemIdLists when view is resettet.
+     */
+    private ItemIdListFactory itemIdListFactory = new DefaultItemIdListFactory();    
+    /**
+     * The current list of item IDs.
      */
     private List<?> itemIdList;
     /**
@@ -604,11 +608,7 @@ public final class LazyQueryView implements QueryView, ValueChangeListener {
      */
     public List<?> getItemIdList() {
         if (itemIdList == null) {
-            if (queryDefinition.getIdPropertyId() != null) {
-                itemIdList = new LazyIdList<Object>(this, queryDefinition.getIdPropertyId());
-            } else {
-                itemIdList = new NaturalNumberIdsList(size());
-            }
+        	this.itemIdList = this.itemIdListFactory.produce(queryDefinition, this);
         }
 
         return itemIdList;
@@ -636,4 +636,12 @@ public final class LazyQueryView implements QueryView, ValueChangeListener {
     public Collection<Container.Filter> getFilters() {
         return queryDefinition.getFilters();
     }
+
+	public ItemIdListFactory getItemIdListFactory() {
+		return itemIdListFactory;
+	}
+
+	public void setItemIdListFactory(ItemIdListFactory itemIdListFactory) {
+		this.itemIdListFactory = itemIdListFactory;
+	}    
 }

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryView.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/LazyQueryView.java
@@ -144,18 +144,34 @@ public final class LazyQueryView implements QueryView, ValueChangeListener {
      * @param queryFactory    The QueryFactory to be used.
      */
     public LazyQueryView(final QueryDefinition queryDefinition, final QueryFactory queryFactory) {
-        initialize(queryDefinition, queryFactory);
+        this(queryDefinition, queryFactory, null);
     }
-
+    
     /**
+	 * Constructs LazyQueryView with given QueryDefinition and QueryFactory. The
+     * role of this constructor is to enable use of custom QueryDefinition
+     * implementations. This constructor also allows customization of
+     * the ItemIdListFactory
+     * 
+     * @param queryDefinition
+     * @param queryFactory
+     * @param itemIdListFactory
+     */
+    public LazyQueryView(final QueryDefinition queryDefinition, final QueryFactory queryFactory, final ItemIdListFactory itemIdListFactory) {
+		this.initialize(queryDefinition, queryFactory, itemIdListFactory);		
+	}
+
+	/**
      * Initializes the LazyQueryView.
      *
      * @param queryDefinition The QueryDefinition to be used.
      * @param queryFactory    The QueryFactory to be used.
+     * @param itemIdListFactory The IdListFactory to be used. If null, a new {@link DefaultItemIdListFactory} is instantiated
      */
-    private void initialize(final QueryDefinition queryDefinition, final QueryFactory queryFactory) {
+    private void initialize(final QueryDefinition queryDefinition, final QueryFactory queryFactory, final ItemIdListFactory itemIdListFactory) {
         this.queryDefinition = queryDefinition;
         this.queryFactory = queryFactory;
+        this.itemIdListFactory = itemIdListFactory == null ? new DefaultItemIdListFactory() : itemIdListFactory;
         this.sortPropertyIds = new Object[0];
         this.ascendingStates = new boolean[0];
     }
@@ -635,13 +651,5 @@ public final class LazyQueryView implements QueryView, ValueChangeListener {
     @Override
     public Collection<Container.Filter> getFilters() {
         return queryDefinition.getFilters();
-    }
-
-	public ItemIdListFactory getItemIdListFactory() {
-		return itemIdListFactory;
-	}
-
-	public void setItemIdListFactory(ItemIdListFactory itemIdListFactory) {
-		this.itemIdListFactory = itemIdListFactory;
-	}    
+    }    
 }

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartItemIdListFactory.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartItemIdListFactory.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2010 Tommi S.E. Laukkanen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.addons.lazyquerycontainer;
 
 import java.util.AbstractList;

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartItemIdListFactory.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartItemIdListFactory.java
@@ -1,0 +1,26 @@
+package org.vaadin.addons.lazyquerycontainer;
+
+import java.util.AbstractList;
+
+/**
+ * The SmartItemIdListFactory uses a {@link SmartLazyIdList} when
+ * the queryDefinition provides an idPropertyId and the the propertytype
+ * of the idPropertyId is a comparable.
+ * 
+ * @author Michael J. Simons, 2013-11-29
+ */
+public class SmartItemIdListFactory implements ItemIdListFactory {
+	private final DefaultItemIdListFactory delegate = new DefaultItemIdListFactory();
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public AbstractList<?> produce(QueryDefinition queryDefinition, LazyQueryView queryView) {
+		AbstractList<?> rv = null;
+		if(queryDefinition.getIdPropertyId() != null && Comparable.class.isAssignableFrom(queryDefinition.getPropertyType(queryDefinition.getIdPropertyId()))) {			
+			rv = new SmartLazyIdList(queryView, queryDefinition.getIdPropertyId());
+		} else {
+			rv = delegate.produce(queryDefinition, queryView);
+		}
+		return rv;
+	}	
+}

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartLazyIdList.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartLazyIdList.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2010 Tommi S.E. Laukkanen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.vaadin.addons.lazyquerycontainer;
 
 import java.io.Serializable;

--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartLazyIdList.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/SmartLazyIdList.java
@@ -1,0 +1,170 @@
+package org.vaadin.addons.lazyquerycontainer;
+
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+
+import com.vaadin.data.Item;
+import com.vaadin.ui.ComboBox;
+
+/**
+ * The SmartLazyIdList is basically a copy of the {@link LazyIdList} with one big difference.
+ * <br>
+ * It requires the IdProperties to be a comparable and assumes those comparables are
+ * in ascending ordner within the container. 
+ * <br>
+ * With this assumption it uses a Binary Search for finding the index of an item. If no index can
+ * be retrieved, it switches to a linear search, like the default implementation.
+ * <br>
+ * The {@link SmartLazyIdList} makes the the {@link LazyQueryContainer} useful as a container for 
+ * Vaadins {@link ComboBox} in combination with very large results from databases or other. 
+ * <br>
+ * The ComboBox needs the index right after filtering and wheres a linear approach might be enough
+ * in many cases, all effort to efficiently filter the container would be wasted if all items
+ * would be paged through anyway right after filtering. 
+ * 
+ * @author Michael J. Simons, 2013-11-28
+ *
+ * @param <T>
+ */
+public class SmartLazyIdList<T extends Comparable<T>> extends AbstractList<T> implements Serializable {	
+	/**
+     * Java serialization version UID.
+     */
+	private static final long serialVersionUID = -1709414329089271002L;
+	/** The logger. */
+    private static final Logger LOGGER = Logger.getLogger(SmartLazyIdList.class);
+    /**
+     * The composite LazyQueryView.
+     */
+    private final LazyQueryView lazyQueryView;
+    /**
+     * The ID of the item ID property.
+     */
+    private final Object idPropertyId;
+    /**
+     * Map containing index to item ID mapping for IDs already loaded through this list.
+     */
+    private final Map<Object, Integer> idIndexMap = new HashMap<Object, Integer>();
+
+    /**
+     * Constructor which sets composite LazyQueryView and ID of the item ID property.
+     *
+     * @param lazyQueryView the LazyQueryView where IDs can be read from.
+     * @param idPropertyId Property containing the property ID.
+     */
+    public SmartLazyIdList(final LazyQueryView lazyQueryView, final Object idPropertyId) {
+        this.lazyQueryView = lazyQueryView;
+        this.idPropertyId = idPropertyId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return lazyQueryView.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public synchronized T[] toArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(final T[] a) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public T get(final int index) {
+        if (index < 0 || index >= lazyQueryView.size()) {
+            throw new IndexOutOfBoundsException();
+        }
+        final T itemId = (T) lazyQueryView.getItem(index).getItemProperty(idPropertyId).getValue();
+        // Do not put added item ids to id index map and make sure that
+        // existing item indexes start from 0 i.e. ignore added items as they
+        // are compensated for in indexOf method.
+        final int addedItemSize = lazyQueryView.getAddedItems().size();
+        if (index >= addedItemSize) {
+            idIndexMap.put(itemId, index - addedItemSize);
+        }
+        return itemId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Integer set(final int index, final Integer element) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */    
+    @SuppressWarnings("unchecked")
+	public int indexOf(final Object o) {
+        if (o == null) {
+            return -1;
+        }
+        // Brute force added items first. There should only be a few.
+        final List<Item> addedItems = lazyQueryView.getAddedItems();
+        for (int i = 0; i < addedItems.size(); i++) {
+            if (o.equals(addedItems.get(i).getItemProperty(idPropertyId).getValue())) {
+                return i;
+            }
+        }
+        // Check from mapping cache.
+        if (idIndexMap.containsKey(o)) {
+            return addedItems.size() + idIndexMap.get(o);
+        }
+        
+        final Comparable<T> comparable = (Comparable<T>) o;        
+        int low = addedItems.size();
+        int high = lazyQueryView.size() - 1;
+        int rv = -1;
+        int iterationCount = 0;
+        while(low<=high && rv < 0) {
+        	int mid = low + (high - low) / 2;        	
+        	int c = comparable.compareTo((T) lazyQueryView.getItem(mid).getItemProperty(idPropertyId).getValue());
+        	if(c<0)
+        		high = mid - 1;
+        	else if(c>0)
+        		low = mid + 1;
+        	else
+        		rv = mid;
+        	++iterationCount;
+        }
+                
+        if(rv >= 0) {
+        	LOGGER.debug(String.format("Used %d iterations to retrieve indexOf item from %d items", iterationCount, lazyQueryView.size()));
+        } else {
+        	LOGGER.warn("Didn't find an index. Please make sure the property Ids are sorted! Switching to linear search.");
+        	 // Switching to brute forcing.
+            for (int i = addedItems.size(); i < lazyQueryView.size(); i++) {
+                if (o.equals(lazyQueryView.getItem(i).getItemProperty(idPropertyId).getValue())) {
+                    return i;
+                }
+            }
+        }
+                
+        return rv;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final Object o) {
+        return indexOf(o) != -1;
+    }
+}

--- a/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/LazyQueryContainerPropertyIdsWithSmartIdListTest.java
+++ b/vaadin-lazyquerycontainer/src/test/java/org/vaadin/addons/lazyquerycontainer/test/LazyQueryContainerPropertyIdsWithSmartIdListTest.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2010 Tommi S.E. Laukkanen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.vaadin.addons.lazyquerycontainer.test;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import junit.framework.TestCase;
+
+import org.apache.log4j.BasicConfigurator;
+import org.vaadin.addons.lazyquerycontainer.LazyQueryContainer;
+import org.vaadin.addons.lazyquerycontainer.LazyQueryDefinition;
+import org.vaadin.addons.lazyquerycontainer.LazyQueryView;
+import org.vaadin.addons.lazyquerycontainer.QueryItemStatus;
+import org.vaadin.addons.lazyquerycontainer.QueryView;
+import org.vaadin.addons.lazyquerycontainer.SmartItemIdListFactory;
+
+import com.vaadin.data.Container.ItemSetChangeEvent;
+import com.vaadin.data.Container.ItemSetChangeListener;
+import com.vaadin.data.Container.PropertySetChangeEvent;
+import com.vaadin.data.Container.PropertySetChangeListener;
+import com.vaadin.data.Item;
+import com.vaadin.data.Property;
+
+/**
+ * JUnit test for testing LazyQueryContainer implementation.
+ *
+ * @author Tommi S.E. Laukkanen
+ */
+@SuppressWarnings("serial")
+public class LazyQueryContainerPropertyIdsWithSmartIdListTest extends TestCase implements ItemSetChangeListener, PropertySetChangeListener {
+
+    private final int viewSize = 100;
+    private LazyQueryContainer container;
+    private boolean itemSetChangeOccurred = false;
+    private boolean propertySetChangeOccurred = false;
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        
+        BasicConfigurator.configure();
+
+        LazyQueryDefinition definition = new LazyQueryDefinition(true, this.viewSize, "Index");
+        definition.addProperty("Index", Integer.class, 0, true, true);
+        definition.addProperty("Reverse Index", Integer.class, 0, true, false);
+        definition.addProperty("Editable", String.class, "", false, false);
+        definition.addProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS, QueryItemStatus.class, QueryItemStatus.None,
+                true, false);
+
+        MockQueryFactory factory = new MockQueryFactory(viewSize, 0, 0);
+        factory.setQueryDefinition(definition);
+        QueryView view = new LazyQueryView(definition, factory, new SmartItemIdListFactory());
+        container = new LazyQueryContainer(view);
+        container.addListener((ItemSetChangeListener) this);
+        container.addListener((PropertySetChangeListener) this);
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    public void testSize() {
+        assertEquals(viewSize, container.size());
+    }
+
+    public void testGetItemIds() {
+        Collection<?> ids = container.getItemIds();
+        Iterator<?> idIterator = ids.iterator();
+        for (int i = 0; i < viewSize; i++) {
+            assertEquals(i, idIterator.next());
+        }
+    }
+
+    public void testGetItem() {
+        for (int i = 0; i < viewSize; i++) {
+            Item item = container.getItem(container.getIdByIndex(i));
+            Property indexProperty = item.getItemProperty("Index");
+            assertEquals(i, indexProperty.getValue());
+            assertTrue(indexProperty.isReadOnly());
+        }
+    }
+
+    public void testAscendingSort() {
+        container.sort(new Object[]{"Index"}, new boolean[]{true});
+
+        for (int i = 0; i < viewSize; i++) {
+            Item item = container.getItem(container.getIdByIndex(i));
+            Property indexProperty = item.getItemProperty("Index");
+            assertEquals(i, indexProperty.getValue());
+            assertTrue(indexProperty.isReadOnly());
+        }
+    }
+
+    public void testDescendingSort() {
+        container.sort(new Object[]{"Index"}, new boolean[]{false});
+
+        for (int i = 0; i < viewSize; i++) {
+            Item item = container.getItem(container.getIdByIndex(i));
+            Property indexProperty = item.getItemProperty("Index");
+            assertEquals(viewSize - i - 1, indexProperty.getValue());
+            assertTrue(indexProperty.isReadOnly());
+        }
+    }
+
+    public void testGetSortablePropertyIds() {
+        Collection<?> sortablePropertyIds = container.getSortableContainerPropertyIds();
+        assertEquals(1, sortablePropertyIds.size());
+        assertEquals("Index", sortablePropertyIds.iterator().next());
+    }
+
+    public void testItemSetChangeNotification() {
+        container.refresh();
+        assertTrue(itemSetChangeOccurred);
+    }
+
+    public void containerItemSetChange(ItemSetChangeEvent event) {
+        itemSetChangeOccurred = true;
+    }
+
+    public void testPropertySetChangeNotification() {
+        container.addContainerProperty("NewProperty", Integer.class, 1, true, true);
+        assertTrue(propertySetChangeOccurred);
+    }
+
+    public void containerPropertySetChange(PropertySetChangeEvent event) {
+        propertySetChangeOccurred = true;
+    }
+
+    public void testAddCommitItem() {
+        int originalViewSize = container.size();
+        assertFalse(container.isModified());
+        int addItemId = (Integer) container.addItem();
+        assertEquals("Item must be added at the beginning", addItemId, -1);
+        assertEquals(originalViewSize + 1, container.size());
+        assertEquals(QueryItemStatus.Added,
+                container.getItem(addItemId).getItemProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+        assertTrue(container.isModified());
+        container.commit();
+        assertFalse(container.isModified());
+        assertEquals(QueryItemStatus.None,
+                container.getItem(addItemId).getItemProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+    }
+
+    public void testAddTwiceCommitItem() {
+        int originalViewSize = container.size();
+        assertFalse(container.isModified());
+        // Add the first Item
+        int addedId = (Integer) container.addItem();
+        assertEquals("Item must be added at the beginning", addedId, -1);
+        assertEquals(originalViewSize + 1, container.size());
+        assertEquals(QueryItemStatus.Added,
+                container.getItem(addedId).getItemProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+        assertTrue(container.isModified());
+        // Add a second Item
+        addedId = (Integer) container.addItem();
+        assertEquals("Second item must be added first as well.", addedId, -2);
+        assertEquals(originalViewSize + 2, container.size());
+        assertEquals(QueryItemStatus.Added,
+                container.getItem(addedId).getItemProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+
+        Collection allItemIds = container.getItemIds();
+        for (Object itemId : allItemIds) {
+            assertEquals(itemId, container.getItem(itemId).getItemProperty("Index").getValue());
+        }
+
+        assertTrue(container.isModified());
+        container.commit();
+        assertFalse(container.isModified());
+        assertEquals(QueryItemStatus.None,
+                container.getItem(addedId).getItemProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+    }
+
+    public void testAddDiscardItem() {
+        int originalViewSize = container.size();
+        assertFalse(container.isModified());
+        int addedId = (Integer) container.addItem();
+        assertEquals("Item must be added at the beginning", addedId, -1);
+        assertEquals(originalViewSize + 1, container.size());
+        assertEquals(QueryItemStatus.Added,
+                container.getItem(addedId).getItemProperty(
+                        LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+        assertTrue(container.isModified());
+        container.discard();
+        assertFalse(container.isModified());
+        assertEquals(originalViewSize, container.size());
+    }
+
+    public void testModifyCommitItem() {
+        int modifyIndex = 0;
+        assertFalse(container.isModified());
+        container.getItem(container.getIdByIndex(modifyIndex)).getItemProperty("Editable").setValue("test");
+        assertTrue(container.isModified());
+        container.commit();
+        assertFalse(container.isModified());
+        assertEquals("test", container.getItem(container.getIdByIndex(modifyIndex)).getItemProperty(
+                "Editable").getValue());
+    }
+
+    public void testModifyDiscardItem() {
+        int modifyIndex = 0;
+        assertFalse(container.isModified());
+        container.getItem(container.getIdByIndex(modifyIndex)).getItemProperty("Editable").setValue("test");
+        assertTrue(container.isModified());
+        container.discard();
+        assertFalse(container.isModified());
+        assertEquals("", container.getItem(container.getIdByIndex(modifyIndex)).getItemProperty("Editable").getValue());
+    }
+
+    public void testRemoveCommitItem() {
+        int removeIndex = 0;
+        int originalViewSize = container.size();
+        assertFalse(container.isModified());
+        assertFalse(container.getItem(container.getIdByIndex(removeIndex)).getItemProperty("Editable").isReadOnly());
+        container.removeItem(removeIndex);
+        assertEquals(originalViewSize, container.size());
+        assertEquals(QueryItemStatus.Removed,
+                container.getItem(removeIndex).getItemProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+        assertTrue(container.getItem(removeIndex).getItemProperty("Editable").isReadOnly());
+        assertTrue(container.isModified());
+        container.commit();
+        assertFalse(container.isModified());
+        assertEquals(originalViewSize - 1, container.size());
+        assertEquals(removeIndex + 1, container.getItem(container.getIdByIndex(removeIndex)).getItemProperty(
+                "Index").getValue());
+    }
+
+    public void testRemoveDiscardItem() {
+        int removeIndex = 0;
+        int originalViewSize = container.size();
+        assertFalse(container.isModified());
+        assertFalse(container.getItem(container.getIdByIndex(removeIndex)).getItemProperty("Editable").isReadOnly());
+        container.removeItem(container.getIdByIndex(removeIndex));
+        assertEquals(originalViewSize, container.size());
+        assertEquals(QueryItemStatus.Removed,
+                container.getItem(container.getIdByIndex(removeIndex)).getItemProperty(LazyQueryView.PROPERTY_ID_ITEM_STATUS).getValue());
+        assertTrue(container.getItem(container.getIdByIndex(removeIndex)).getItemProperty("Editable").isReadOnly());
+        assertTrue(container.isModified());
+        container.discard();
+        assertFalse(container.isModified());
+        assertEquals(originalViewSize, container.size());
+        assertEquals(removeIndex, container.getItem(container.getIdByIndex(removeIndex)).getItemProperty("Index").getValue());
+        assertFalse(container.getItem(container.getIdByIndex(removeIndex)).getItemProperty("Editable").isReadOnly());
+    }
+
+}


### PR DESCRIPTION
Hi Tommi.

I am using your lazyquerycontainer with a custom JPA filter implementation for Vaadins Comboboxes. My own criteria based filtering works very well but in some cases we have really big unfiltered results.

When lazyquerycontainer is used with Vaadins Combobox, a moderate page size and more than some 1000 results, it doesn't work quite well as the Combobox requests the index and the LazyIdList needs to linear search all results for an index leading to querying all objects (not lazy anymore for nothing) and many, many queries.

My request has to components: 

1. Introduce an ItemIdListFactory that produces id lists. Passing this to LazyQueryView keeps its immutable structure but providing an entry point for customization. The original functionality is now in DefaultItemIdListFactory, same as before. All tests are green.

2. Introduce a SmartItemIdListFactory which produces SmartLazyIdList. With the requirement of the idPropertyIds being comparable to each other and the assumption that they are in ascending order a binary search for an index can be used which makes the container suitable for ComboBox with more than (tested) 100.000 entries.

What do you think? The fork is based on tag 2.1.0. I've added a custom version for the time being.

I really hope this makes into your upstream and that you'll release a new version in the near future.

Again, thank you for your work and letting me participate.

Michael