### PR TITLE
#85: Don't rely on setter present when passing default values for newly created items

### DIFF
--- a/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/AbstractBeanQuery.java
+++ b/vaadin-lazyquerycontainer/src/main/java/org/vaadin/addons/lazyquerycontainer/AbstractBeanQuery.java
@@ -115,7 +115,7 @@ public abstract class AbstractBeanQuery<T> implements Query, Serializable {
             BeanInfo info = Introspector.getBeanInfo(bean.getClass());
             for (PropertyDescriptor pd : info.getPropertyDescriptors()) {
                 for (Object propertyId : queryDefinition.getPropertyIds()) {
-                    if (pd.getName().equals(propertyId)) {
+                    if (pd.getName().equals(propertyId) && pd.getWriteMethod() != null) {
                         pd.getWriteMethod().invoke(bean,
                                 queryDefinition.getPropertyDefaultValue(propertyId));
                     }


### PR DESCRIPTION
Added null check. Works for me.
